### PR TITLE
Extract build.sh from release.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+./update.sh
+
+source ./variants.sh
+
+for variant in "${variants[@]}"; do
+    image=${images[$variant]}
+    echo "Building ${image}"
+
+    docker build -t $image "${variant}/"
+done

--- a/release.sh
+++ b/release.sh
@@ -6,18 +6,10 @@ if [[ -n $(git status -s) ]]; then
     exit 1
 fi
 
-./update.sh
+./build.sh
 
-declare variants=( */ )
-variants=( "${variants[@]%/}" )
+source ./variants.sh
 
-for variant in "${variants[@]}"; do
-    tag=$(cat "${variant}/tag");
-    image="quay.io/democracyworks/clojure-yourkit:${tag}"
-
-    echo "Building ${image}"
-
-    docker build -t $image "${variant}/"
-
+for image in "${images[@]}"; do
     docker push ${image}
 done

--- a/variants.sh
+++ b/variants.sh
@@ -1,0 +1,12 @@
+# intended to be sourced by other scripts, not run directly
+
+declare variants=( */ )
+variants=( "${variants[@]%/}" )
+
+declare -A tags
+declare -A images
+
+for variant in "${variants[@]}"; do
+    tags[$variant]=$(cat "${variant}/tag");
+    images[$variant]="quay.io/democracyworks/clojure-yourkit:${tags[$variant]}"
+done


### PR DESCRIPTION
...and put common functionality into shared variants.sh file that they both source.

This is handy for building local images to test before pushing them to Quay.